### PR TITLE
use switch-case for REPOSITORIES internal variable

### DIFF
--- a/Dockerfile.bootstrap
+++ b/Dockerfile.bootstrap
@@ -7,13 +7,14 @@ RUN apk add ca-certificates curl && \
   curl ${REPOSITORY}/static/xbps-static-static-0.59_5.$(uname -m)-musl.tar.xz | \
         tar vJx && \
         rm -f /etc/ssl/certs/2e5ac55d.* && \
-  if [ "${ARCH%-musl}" = "aarch64" ]; then \
-    export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-  elif [[ "${ARCH}" = "*-musl" ]]; then \
-    export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-  else \
-    export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-  fi; \
+  case "${ARCH}" in \
+    aarch64*) \
+        export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+    *-musl) \
+        export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+    *) \
+        export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+  esac; \
   XBPS_ARCH=${ARCH} xbps-install.static -yMU \
     $REPOSITORIES \
     -r /target \

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -5,13 +5,14 @@ COPY keys/* /target/var/db/xbps/keys/
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMUS \
         $REPOSITORIES \
         -r /target \

--- a/Dockerfile.masterdir
+++ b/Dockerfile.masterdir
@@ -5,13 +5,14 @@ COPY keys/* /target/var/db/xbps/keys/
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMUS \
         $REPOSITORIES \
         -r /target \

--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -6,13 +6,14 @@ COPY noextract.conf /target/etc/xbps.d/noextract.conf
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMU \
         $REPOSITORIES \
         -r /target \

--- a/Dockerfile.mini-bb
+++ b/Dockerfile.mini-bb
@@ -6,13 +6,14 @@ COPY noextract.conf /target/etc/xbps.d/noextract.conf
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMU \
         $REPOSITORIES \
         -r /target \

--- a/Dockerfile.thin
+++ b/Dockerfile.thin
@@ -6,13 +6,14 @@ COPY noextract.conf /target/etc/xbps.d/noextract.conf
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMU \
         $REPOSITORIES \
         -r /target \

--- a/Dockerfile.thin-bb
+++ b/Dockerfile.thin-bb
@@ -6,13 +6,14 @@ COPY noextract.conf /target/etc/xbps.d/noextract.conf
 ARG REPOSITORY=https://repo-us.voidlinux.org
 ARG ARCH=x86_64
 RUN \
-        if [ "${ARCH%-musl}" = "aarch64" ]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64"; \
-        elif [[ "${ARCH}" = "*-musl" ]]; then \
-                export REPOSITORIES="--repository=${REPOSITORY}/current/musl"; \
-        else \
-                export REPOSITORIES="--repository=${REPOSITORY}/current"; \
-        fi; \
+        case "${ARCH}" in \
+        aarch64*) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/aarch64" ;; \
+        *-musl) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current/musl" ;; \
+        *) \
+            export REPOSITORIES="--repository=${REPOSITORY}/current" ;; \
+        esac; \
         XBPS_ARCH=${ARCH} xbps-install -yMU \
         $REPOSITORIES \
         -r /target \


### PR DESCRIPTION
while attempting to build the images myself (on my Void system), I kept hitting `[[: not found` errors, I don't know if going to switch-case is the right approach, but it should work on all POSIX shells (and the images do build, though I haven't manually tested all of them).