### PR TITLE
mini, mini-bb, thin-bb: fix build when xbps needs updating

### DIFF
--- a/Dockerfile.mini
+++ b/Dockerfile.mini
@@ -19,7 +19,7 @@ RUN \
         -r /target \
         xbps base-files dash coreutils grep run-parts sed gawk && \
         rm -rf /target/var/cache/
-RUN xbps-install -yMU binutils && \
+RUN xbps-install -yMU xbps && xbps-install -yMU binutils && \
         strip /target/usr/lib/* /target/usr/bin/* || exit 0
 
 FROM scratch

--- a/Dockerfile.mini-bb
+++ b/Dockerfile.mini-bb
@@ -19,7 +19,7 @@ RUN \
         -r /target \
         xbps base-files busybox-huge && \
         rm -rf /target/var/cache/
-RUN xbps-install -yMU busybox-huge binutils && \
+RUN xbps-install -yMU xbps && xbps-install -yMU busybox-huge binutils && \
 for util in $(busybox --list) ; do [ ! -f /target/usr/bin/$util ] && ln -svf /usr/bin/busybox /target/usr/bin/$util ; done && \
 strip /target/usr/lib/* /target/usr/bin/* || exit 0
 

--- a/Dockerfile.thin-bb
+++ b/Dockerfile.thin-bb
@@ -19,7 +19,7 @@ RUN \
         -r /target \
         xbps base-files busybox-huge && \
         rm -rf /target/var/cache/
-RUN xbps-install -yMU busybox-huge && \
+RUN xbps-install -yMU xbps && xbps-install -yMU busybox-huge && \
 for util in $(busybox --list) ; do [ ! -f /target/usr/bin/$util ] && ln -svf /usr/bin/busybox /target/usr/bin/$util ; done
 
 FROM scratch


### PR DESCRIPTION
xbps is not updated from the bootstrap image version for the / rootdir. This causes the second RUN directive to fail, sometimes silently because of the `|| exit 0`.

There is still the outstanding issue of #7, but all images now [successfully build](https://github.com/classabbyamp/void-docker/actions/runs/2410475764).