### PR TITLE
Dockerfile.masterdir: include void-repo-bootstrap so things can update

### DIFF
--- a/Dockerfile.masterdir
+++ b/Dockerfile.masterdir
@@ -17,7 +17,7 @@ RUN \
         $REPOSITORIES \
         $REPOSITORIES/bootstrap \
         -r /target \
-        base-chroot chroot-curl
+        base-chroot chroot-curl void-repo-bootstrap
 
 FROM scratch
 LABEL org.opencontainers.image.source https://github.com/void-linux/void-docker


### PR DESCRIPTION
updates to base-chroot and chroot-curl can make it impossible to update in CI. This ensures the CI container has access to the bootstrap repo.

depends on void-linux/void-packages#43610
