### PR TITLE
remove trailing slash

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: "${MIRROR:=https://repo-ci.voidlinux.org/}"
+: "${MIRROR:=https://repo-ci.voidlinux.org}"
 
 suffix() {
 	case "${LIBC:?}" in


### PR DESCRIPTION
was causing double slash in $REPO