### PR TITLE
.github/workflows/build: enable pushing to dockerhub

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,6 +58,7 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/void-${{ matrix.libc }}${{ matrix.variant }}
+            docker.io/voidlinux/void-${{ matrix.libc }}${{ matrix.variant }}
           tags: |
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
@@ -85,6 +86,13 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push images
         id: build_and_push


### PR DESCRIPTION
despite dockerhub's checkered recent past, I think this is beneficial, especially as alpha.de's DNS no longer works, breaking people who use the current dockerhub container as-is. If we do this, we should be able to remove the old images and direct people to the new ones.

This will require dockerhub credentials be added as secrets.
