### PR TITLE
Fix path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM --platform=${BUILDPLATFORM} alpine:3.22 AS bootstrap
+FROM --platform=${BUILDPLATFORM} docker.io/alpine:3.22 AS bootstrap
 ARG TARGETPLATFORM
 ARG MIRROR=https://repo-ci.voidlinux.org
 ARG LIBC

--- a/Containerfile
+++ b/Containerfile
@@ -58,6 +58,7 @@ RUN \
   install -dm1777 tmp; \
   xbps-reconfigure -fa; \
   rm -rf /var/cache/xbps/*
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
 CMD ["/bin/sh"]
 
 FROM scratch AS image-busybox
@@ -69,6 +70,7 @@ RUN \
   install -dm1777 tmp; \
   xbps-reconfigure -fa; \
   rm -rf /var/cache/xbps/*
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
 CMD ["/bin/sh"]
 
 FROM scratch AS image-full
@@ -77,4 +79,5 @@ RUN \
   install -dm1777 tmp; \
   xbps-reconfigure -fa; \
   rm -rf /var/cache/xbps/*
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/bin
 CMD ["/bin/sh"]


### PR DESCRIPTION
Changes the PATH to match `/etc/runit/{1,2,3}`.

```
void-containers% podman run --rm -it ghcr.io/void-linux/void-glibc sh -c 'echo $PATH'
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

void-containers% podman build --target "image-default" --build-arg="LIBC=musl" . --tag fixed-path
void-containers% podman run --rm -it fixed-path sh -c 'echo $PATH'
/usr/bin:/usr/sbin
```

This resolves https://github.com/void-linux/void-packages/issues/58440.